### PR TITLE
pass missing argument to oauth2_error in _oauth2_dpop_jti_validate

### DIFF
--- a/src/dpop.c
+++ b/src/dpop.c
@@ -310,7 +310,7 @@ static bool _oauth2_dpop_jti_validate(oauth2_log_t *log,
 	oauth2_cache_get(log, verify->cache, clm_jti, &s_value);
 	if (s_value != NULL) {
 		oauth2_error(log, "a token with the same JTI \"%s\" exists in "
-				  "the cache: possible replay attack");
+				  "the cache: possible replay attack", clm_jti);
 		goto end;
 	}
 


### PR DESCRIPTION
Fixes a crash in test/check_oauth2.c

Signed-off-by: Alexander Bokovoy <abokovoy@redhat.com>