### PR TITLE
Fix use of strchr with new GCC

### DIFF
--- a/src/jose.c
+++ b/src/jose.c
@@ -993,7 +993,7 @@ char *oauth2_jose_jwt_header_peek(oauth2_log_t *log,
 {
 	char *input = NULL, *result = NULL;
 	json_t *json = NULL;
-	char *p = NULL;
+	const char *p = NULL;
 	size_t result_len;
 	char *rv = NULL;
 


### PR DESCRIPTION
According to C specification, 7.28.5.1, strchr() is a generic function and its string argument's type is promoted to the result. So if it is const char*, the result will be const char* as well.

gcc in Fedora Rawhide (15.2.1 20251111 or later) implements this conformance, resulting in a compilation fail with
-Werror=discarded-qualifiers.